### PR TITLE
Put sudo config in its own file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
     apt-get update && \
     # Blank password \
     echo 'neon:U6aMy0wojraho' | chpasswd -e && \
-    echo 'neon ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    echo 'neon ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/neon && \
     apt-get clean && \
     cp /usr/lib/x86_64-linux-gnu/libexec/kf5/start_kdeinit /root/ && \
     rm /usr/lib/x86_64-linux-gnu/libexec/kf5/start_kdeinit && \


### PR DESCRIPTION
Current code changes `/etc/sudoers`, which belongs to sudo. If you use this image as a base and somehow have to update sudo, it asks if you want to keep `/etc/sudoers` or overwrite it with the default file. The build then fails cause there is no user input. This patch will change the behavior: it will create a file named `/etc/sudoers.d/neon`, which is included by the `/etc/sudoers` provided by sudo.